### PR TITLE
🐛 fix: avoid Tailscale socket on unsupported platforms

### DIFF
--- a/lib/servers/ssh_connection_manager.dart
+++ b/lib/servers/ssh_connection_manager.dart
@@ -18,6 +18,7 @@ import 'ssh_proxy_connect.dart';
 import 'socks5_protocol.dart';
 import 'systemd_models.dart';
 import 'tailscale_ssh_socket.dart';
+import 'tailscale_service.dart';
 import 'terminal_session_adapter.dart';
 import 'web_server_adapter.dart';
 import 'web_server_adapters.dart';
@@ -3638,7 +3639,7 @@ uname -r
     final identities = credential.type == CredentialType.privateKey
         ? SSHKeyPair.fromPem(credential.privateKey!, credential.keyPassphrase)
         : null;
-    final socket = isTailnetAddress(server.host)
+    final socket = isTailnetAddress(server.host) && tailscaleSupported
         ? await TailscaleSshSocket.connect(server.host, server.port)
         : await _LowLatencySshSocket.connect(
             server.host,


### PR DESCRIPTION
## 修复：不支持内置 Tailscale 的平台回退直连 tailnet 地址

### 问题

Android（以及 Windows/Web）不支持 `package:tailscale` 的内置节点功能（`tailscaleSupported` 仅 macOS/Linux 为 `true`）。

当连接目标地址位于 Tailscale CGNAT 网段（`100.64.0.0/10`）时，`SshConnectionManager._createClient` 会无条件尝试使用 `TailscaleSshSocket.connect`，导致不支持平台触发：

```
Tailscale is not connected. Open Settings → Tailscale to sign in.
```

实际原因是当前平台不支持内置 Tailscale，而非用户未连接 Tailscale。

### 修改

修改 `lib/servers/ssh_connection_manager.dart`：

* 增加 `tailscaleSupported` 判断。
* 仅在平台支持内置 Tailscale 时，tailnet 地址才使用 `TailscaleSshSocket.connect`。
* 不支持的平台回退到 `_LowLatencySshSocket.connect`，保持普通 SSH 直连行为。
* 新增 `import 'tailscale_service.dart'` 用于访问 `tailscaleSupported`。

```diff
- final socket = isTailnetAddress(server.host)
+ final socket = isTailnetAddress(server.host) && tailscaleSupported
      ? await TailscaleSshSocket.connect(server.host, server.port)
      : await _LowLatencySshSocket.connect(server.host, server.port, proxy: proxy);
```

`isTailnetAddress` 判断逻辑保持不变，未影响其他连接流程。

### 影响范围

✅ macOS/Linux

* 行为保持不变。
* tailnet 地址继续使用内置 Tailscale SSH socket。

✅ Android/Windows/Web

* 不再尝试初始化不支持的内置 Tailscale。
* tailnet 地址改为普通 SSH 直连。
* 消除误导性的 “Tailscale is not connected” 错误。

### 测试

* 验证支持 Tailscale 平台上的 tailnet SSH 连接行为保持一致。
* 验证不支持平台连接 `100.64.0.0/10` 地址时能够正常回退直连。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Solsynth/codesmith/MaidKit/pr/23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788885588&installation_model_id=431261&pr_number=23&repository=Solsynth%2FMaidKit&return_to=https%3A%2F%2Fgithub.com%2FSolsynth%2FMaidKit%2Fpull%2F23&signature=8110aef42fd5f6f9eb7c4b6839bfc1ac2915a96eb26ae64e6086be8ea989a024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->