### PR TITLE
fix: persist appearance preferences

### DIFF
--- a/lib/servers/app_theme_preferences.dart
+++ b/lib/servers/app_theme_preferences.dart
@@ -3,19 +3,34 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 abstract interface class AppThemeSettings {
   Color get seedColor;
+  ThemeMode get themeMode;
+  bool get compactDashboard;
 
   Future<void> saveSeedColor(Color color);
+  Future<void> saveThemeMode(ThemeMode mode);
+  Future<void> saveCompactDashboard(bool compact);
 }
 
 class AppThemePreferences implements AppThemeSettings {
-  AppThemePreferences(this._preferences, this.seedColor);
+  AppThemePreferences(
+    this._preferences,
+    this.seedColor,
+    this.themeMode,
+    this.compactDashboard,
+  );
 
   static const _seedColorKey = 'app_theme_seed_color';
+  static const _themeModeKey = 'app_theme_mode';
+  static const _compactDashboardKey = 'app_dashboard_compact_view';
   static const _defaultSeedColor = Color(0xFF0F766E);
 
   final SharedPreferencesAsync _preferences;
   @override
   final Color seedColor;
+  @override
+  final ThemeMode themeMode;
+  @override
+  final bool compactDashboard;
 
   static Future<AppThemePreferences> load({
     SharedPreferencesAsync? preferences,
@@ -24,21 +39,50 @@ class AppThemePreferences implements AppThemeSettings {
     return AppThemePreferences(
       store,
       Color(await store.getInt(_seedColorKey) ?? _defaultSeedColor.toARGB32()),
+      _decodeThemeMode(await store.getString(_themeModeKey)),
+      await store.getBool(_compactDashboardKey) ?? false,
     );
   }
+
+  static ThemeMode _decodeThemeMode(String? value) =>
+      ThemeMode.values.where((mode) => mode.name == value).firstOrNull ??
+      ThemeMode.system;
 
   @override
   Future<void> saveSeedColor(Color color) async {
     await _preferences.setInt(_seedColorKey, color.toARGB32());
   }
+
+  @override
+  Future<void> saveThemeMode(ThemeMode mode) =>
+      _preferences.setString(_themeModeKey, mode.name);
+
+  @override
+  Future<void> saveCompactDashboard(bool compact) =>
+      _preferences.setBool(_compactDashboardKey, compact);
 }
 
 class InMemoryAppThemeSettings implements AppThemeSettings {
-  InMemoryAppThemeSettings({this.seedColor = const Color(0xFF0F766E)});
+  InMemoryAppThemeSettings({
+    this.seedColor = const Color(0xFF0F766E),
+    this.themeMode = ThemeMode.system,
+    this.compactDashboard = false,
+  });
 
   @override
   Color seedColor;
+  @override
+  ThemeMode themeMode;
+  @override
+  bool compactDashboard;
 
   @override
   Future<void> saveSeedColor(Color color) async => seedColor = color;
+
+  @override
+  Future<void> saveThemeMode(ThemeMode mode) async => themeMode = mode;
+
+  @override
+  Future<void> saveCompactDashboard(bool compact) async =>
+      compactDashboard = compact;
 }

--- a/lib/servers/server_providers.dart
+++ b/lib/servers/server_providers.dart
@@ -588,9 +588,12 @@ final themeModeProvider = NotifierProvider<ThemeModeNotifier, ThemeMode>(
 
 class ThemeModeNotifier extends Notifier<ThemeMode> {
   @override
-  ThemeMode build() => ThemeMode.system;
+  ThemeMode build() => ref.read(appThemeSettingsProvider).themeMode;
 
-  void setThemeMode(ThemeMode mode) => state = mode;
+  Future<void> setThemeMode(ThemeMode mode) async {
+    await ref.read(appThemeSettingsProvider).saveThemeMode(mode);
+    state = mode;
+  }
 }
 
 final appThemeSettingsProvider = Provider<AppThemeSettings>(
@@ -608,6 +611,21 @@ class AppSeedColorNotifier extends Notifier<Color> {
   Future<void> setSeedColor(Color color) async {
     await ref.read(appThemeSettingsProvider).saveSeedColor(color);
     state = color;
+  }
+}
+
+final dashboardCompactViewProvider =
+    NotifierProvider<DashboardCompactViewNotifier, bool>(
+      DashboardCompactViewNotifier.new,
+    );
+
+class DashboardCompactViewNotifier extends Notifier<bool> {
+  @override
+  bool build() => ref.read(appThemeSettingsProvider).compactDashboard;
+
+  Future<void> setCompact(bool compact) async {
+    await ref.read(appThemeSettingsProvider).saveCompactDashboard(compact);
+    state = compact;
   }
 }
 

--- a/lib/servers/servers_page.dart
+++ b/lib/servers/servers_page.dart
@@ -269,7 +269,7 @@ class _ServersCatalog extends StatelessWidget {
   }
 }
 
-class _ServerGrid extends StatefulWidget {
+class _ServerGrid extends ConsumerStatefulWidget {
   const _ServerGrid({
     required this.servers,
     required this.sessions,
@@ -297,13 +297,12 @@ class _ServerGrid extends StatefulWidget {
   final ValueChanged<Server> onRefresh;
 
   @override
-  State<_ServerGrid> createState() => _ServerGridState();
+  ConsumerState<_ServerGrid> createState() => _ServerGridState();
 }
 
-class _ServerGridState extends State<_ServerGrid> {
+class _ServerGridState extends ConsumerState<_ServerGrid> {
   var _isReconnecting = false;
   var _isArranging = false;
-  var _isCompactView = false;
   var _isSavingOrder = false;
   final _selectedTags = <String>{};
   List<int>? _pendingOrder;
@@ -360,6 +359,7 @@ class _ServerGridState extends State<_ServerGrid> {
 
   @override
   Widget build(BuildContext context) {
+    final isCompactView = ref.watch(dashboardCompactViewProvider);
     final sessionsByServerId = {
       for (final session in widget.sessions) session.serverId: session,
     };
@@ -456,7 +456,7 @@ class _ServerGridState extends State<_ServerGrid> {
                   sliver: SliverGrid(
                     gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
                       maxCrossAxisExtent: 380,
-                      mainAxisExtent: _isCompactView ? 200 : 320,
+                      mainAxisExtent: isCompactView ? 200 : 320,
                       mainAxisSpacing: 16,
                       crossAxisSpacing: 16,
                     ),
@@ -466,7 +466,7 @@ class _ServerGridState extends State<_ServerGrid> {
                       final card = _ServerCard(
                         server: server,
                         session: session,
-                        compact: _isCompactView,
+                        compact: isCompactView,
                         onConnect: () => widget.onConnect(server),
                         onOpenDetail: () => widget.onOpenDetail(server),
                         onOpenTerminal: () => widget.onOpenTerminal(server),
@@ -519,6 +519,7 @@ class _ServerGridState extends State<_ServerGrid> {
   }
 
   Widget _arrangeServersFooter(BuildContext context) {
+    final isCompactView = ref.watch(dashboardCompactViewProvider);
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
       child: Column(
@@ -528,13 +529,14 @@ class _ServerGridState extends State<_ServerGrid> {
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
               OutlinedButton.icon(
-                onPressed: () =>
-                    setState(() => _isCompactView = !_isCompactView),
+                onPressed: () => ref
+                    .read(dashboardCompactViewProvider.notifier)
+                    .setCompact(!isCompactView),
                 icon: Icon(
-                  _isCompactView ? Symbols.view_agenda : Symbols.view_compact,
+                  isCompactView ? Symbols.view_agenda : Symbols.view_compact,
                 ),
                 label: Text(
-                  _isCompactView
+                  isCompactView
                       ? 'serversDetailedView'.tr()
                       : 'serversCompactView'.tr(),
                 ),

--- a/test/app_theme_preferences_test.dart
+++ b/test/app_theme_preferences_test.dart
@@ -18,4 +18,38 @@ void main() {
     expect(settings.seedColor, color);
     expect(container.read(appSeedColorProvider), color);
   });
+
+  test('restores and saves the theme mode', () async {
+    final settings = InMemoryAppThemeSettings(themeMode: ThemeMode.dark);
+    final container = ProviderContainer(
+      overrides: [appThemeSettingsProvider.overrideWithValue(settings)],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(themeModeProvider), ThemeMode.dark);
+
+    await container
+        .read(themeModeProvider.notifier)
+        .setThemeMode(ThemeMode.light);
+
+    expect(settings.themeMode, ThemeMode.light);
+    expect(container.read(themeModeProvider), ThemeMode.light);
+  });
+
+  test('restores and saves the compact dashboard preference', () async {
+    final settings = InMemoryAppThemeSettings(compactDashboard: true);
+    final container = ProviderContainer(
+      overrides: [appThemeSettingsProvider.overrideWithValue(settings)],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(dashboardCompactViewProvider), isTrue);
+
+    await container
+        .read(dashboardCompactViewProvider.notifier)
+        .setCompact(false);
+
+    expect(settings.compactDashboard, isFalse);
+    expect(container.read(dashboardCompactViewProvider), isFalse);
+  });
 }


### PR DESCRIPTION
## Summary

- persist the selected system, light, or dark theme mode
- persist the dashboard compact/detailed layout
- restore both preferences during application startup
- add notifier regression coverage for restoring and saving both values

## Validation

- `dart analyze lib/servers/app_theme_preferences.dart lib/servers/server_providers.dart lib/servers/servers_page.dart test/app_theme_preferences_test.dart` — no issues
- `flutter test test/app_theme_preferences_test.dart` is currently blocked on Windows by the existing `tailscale 0.8.0` native build referencing POSIX-only symbols

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Solsynth/codesmith/MaidKit/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789278640&installation_model_id=431261&pr_number=36&repository=Solsynth%2FMaidKit&return_to=https%3A%2F%2Fgithub.com%2FSolsynth%2FMaidKit%2Fpull%2F36&signature=4e4f7bee35fe1ba11751354fbed52380e2285a00392f7f5a41e3a0f495c70008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->