### PR TITLE
fix: include build number in update checks

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,8 +9,8 @@ import 'package:island_ui_foundation/island_ui_foundation.dart';
 import 'agent/local_mcp_server.dart';
 import 'routing/app_router.dart';
 import 'shared/presentation/maidkit_window_scaffold.dart';
-import 'package:solsynth_express/solsynth_express.dart';
 import 'servers/server_providers.dart';
+import 'shared/services/maidkit_update_service.dart';
 import 'shared/services/update_preferences.dart';
 import 'servers/startup_connection_bootstrap.dart';
 import 'servers/tailscale_auto_connect.dart';
@@ -54,7 +54,7 @@ class _MaidKitAppState extends ConsumerState<MaidKitApp> {
       );
       final updateChannel = await ref.read(maidKitUpdateChannelProvider.future);
       if (!mounted || !ctx.mounted) return;
-      await UpdateService(
+      await MaidKitUpdateService.forProduct(
         channel: updateChannel,
         productId: kMaidKitDistributionProductId,
         enabled: updateChecksEnabled,

--- a/lib/servers/about_page.dart
+++ b/lib/servers/about_page.dart
@@ -7,7 +7,7 @@ import 'package:styled_widget/styled_widget.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:maid_kit/shared/services/package_info_provider.dart';
-import 'package:solsynth_express/solsynth_express.dart';
+import 'package:maid_kit/shared/services/maidkit_update_service.dart';
 import 'package:maid_kit/shared/services/update_preferences.dart';
 
 /// Opens the Solar Network product page in the default browser.
@@ -146,7 +146,7 @@ class AboutPage extends ConsumerWidget {
                       subtitle: Text('checkForUpdatesHint'.tr()),
                       trailing: const Icon(Symbols.chevron_right),
                       onTap: () async {
-                        await UpdateService(
+                        await MaidKitUpdateService.forProduct(
                           channel: updateChannel,
                           productId: kMaidKitDistributionProductId,
                           enabled: true,

--- a/lib/shared/presentation/update_settings_section.dart
+++ b/lib/shared/presentation/update_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:solsynth_express/solsynth_express.dart';
 
 import '../services/update_preferences.dart';
+import '../services/maidkit_update_service.dart';
 
 class MaidKitUpdateSettingsSection extends ConsumerStatefulWidget {
   const MaidKitUpdateSettingsSection({super.key});
@@ -22,7 +23,7 @@ class _MaidKitUpdateSettingsSectionState
   @override
   void initState() {
     super.initState();
-    _channelsFuture = UpdateService(
+    _channelsFuture = MaidKitUpdateService.forProduct(
       productId: kMaidKitDistributionProductId,
     ).fetchChannels();
   }
@@ -39,11 +40,11 @@ class _MaidKitUpdateSettingsSectionState
     if (_latestReleaseKey != latestKey) {
       _latestReleaseKey = latestKey;
       _latestReleaseFuture = enabled
-          ? UpdateService(
+          ? MaidKitUpdateService.forProduct(
               channel: channel,
               productId: kMaidKitDistributionProductId,
               enabled: true,
-            ).fetchLatestRelease()
+            ).fetchLatestAvailableRelease()
           : Future.value(null);
     }
 
@@ -127,7 +128,7 @@ class _MaidKitUpdateSettingsSectionState
                   : const Icon(Icons.chevron_right),
               onTap: release == null
                   ? null
-                  : () => UpdateService(
+                  : () => MaidKitUpdateService.forProduct(
                       channel: channel,
                       productId: kMaidKitDistributionProductId,
                       enabled: true,
@@ -140,7 +141,7 @@ class _MaidKitUpdateSettingsSectionState
           alignment: Alignment.centerRight,
           child: TextButton.icon(
             onPressed: () async {
-              await UpdateService(
+              await MaidKitUpdateService.forProduct(
                 channel: channel,
                 productId: kMaidKitDistributionProductId,
                 enabled: true,

--- a/lib/shared/services/maidkit_update_service.dart
+++ b/lib/shared/services/maidkit_update_service.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:solsynth_express/solsynth_express.dart';
+
+/// Build-number-aware update checks for MaidKit.
+///
+/// Android commonly keeps the human-readable version name unchanged between
+/// builds. Comparing only [PackageInfo.version] repeatedly offers the same APK
+/// to users who have already installed it.
+class MaidKitUpdateService extends UpdateService {
+  MaidKitUpdateService({
+    required SolsynthExpressApi api,
+    super.channel,
+    super.enabled,
+  }) : _api = api,
+       super(api: api);
+
+  factory MaidKitUpdateService.forProduct({
+    required String productId,
+    String channel = 'stable',
+    bool enabled = true,
+  }) {
+    final api = SolsynthExpressApi(
+      baseUrl: const String.fromEnvironment('DISTRIBUTION_API_BASE_URL'),
+      productId: productId,
+    );
+    return MaidKitUpdateService(api: api, channel: channel, enabled: enabled);
+  }
+
+  final SolsynthExpressApi _api;
+
+  @override
+  Future<void> checkForUpdates(BuildContext context) async {
+    if (!enabled || kIsWeb || !_api.isConfigured) return;
+    try {
+      final info = await PackageInfo.fromPlatform();
+      final target = await _currentTarget();
+      if (target == null) return;
+      final currentVersion = installedUpdateVersion(info);
+      final result = await _api.checkForUpdate(
+        currentVersion: currentVersion,
+        platform: target.platform,
+        architecture: target.architecture,
+        channel: channel,
+        clientVersion: currentVersion,
+      );
+      final release = result.release;
+      if (!result.updateAvailable ||
+          release == null ||
+          !isDistributionReleaseNewer(release.tagName, currentVersion) ||
+          !context.mounted) {
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      if (context.mounted) await showUpdateSheet(context, release);
+    } catch (error, stackTrace) {
+      Logger.root.severe('[MaidKit] Update check failed', error, stackTrace);
+    }
+  }
+
+  /// Returns null when the newest published release is already installed.
+  Future<DistributionReleaseInfo?> fetchLatestAvailableRelease() async {
+    final release = await fetchLatestRelease();
+    if (release == null) return null;
+    final currentVersion = installedUpdateVersion(
+      await PackageInfo.fromPlatform(),
+    );
+    return isDistributionReleaseNewer(release.tagName, currentVersion)
+        ? release
+        : null;
+  }
+
+  Future<_UpdateTarget?> _currentTarget() async {
+    if (kIsWeb) return null;
+    final platform = Platform.isAndroid
+        ? 'android'
+        : Platform.isWindows
+        ? 'windows'
+        : Platform.isLinux
+        ? 'linux'
+        : Platform.isMacOS
+        ? 'macos'
+        : Platform.isIOS
+        ? 'ios'
+        : '';
+    if (platform.isEmpty) return null;
+    final architecture = await _currentArchitecture();
+    return architecture.isEmpty ? null : _UpdateTarget(platform, architecture);
+  }
+
+  Future<String> _currentArchitecture() async {
+    if (Platform.isAndroid) {
+      final info = await DeviceInfoPlugin().androidInfo;
+      for (final abi in info.supportedAbis) {
+        switch (abi) {
+          case 'arm64-v8a':
+            return 'arm64';
+          case 'armeabi-v7a':
+            return 'armeabi-v7a';
+          case 'x86_64':
+            return 'x86_64';
+          case 'x86':
+            return 'x86';
+        }
+      }
+    }
+    if (Platform.isWindows) {
+      final value =
+          Platform.environment['PROCESSOR_ARCHITEW6432'] ??
+          Platform.environment['PROCESSOR_ARCHITECTURE'];
+      if (value != null) {
+        return switch (value.toUpperCase()) {
+          'AMD64' || 'X86_64' => 'amd64',
+          'ARM64' => 'arm64',
+          _ => value.toLowerCase(),
+        };
+      }
+    }
+    if (Platform.isLinux) return 'amd64';
+    if (Platform.isMacOS || Platform.isIOS) return 'arm64';
+    return '';
+  }
+}
+
+String installedUpdateVersion(PackageInfo info) {
+  final build = info.buildNumber.trim();
+  return build.isEmpty ? info.version : '${info.version}+$build';
+}
+
+bool isDistributionReleaseNewer(String release, String installed) {
+  final remote = _tryParseVersion(release);
+  final local = _tryParseVersion(installed);
+  if (remote == null || local == null) return release != installed;
+  final precedence = remote.compareTo(local);
+  if (precedence != 0) return precedence > 0;
+
+  final remoteBuild = int.tryParse(remote.build.firstOrNull?.toString() ?? '');
+  final localBuild = int.tryParse(local.build.firstOrNull?.toString() ?? '');
+  if (remoteBuild == null) return false;
+  return remoteBuild > (localBuild ?? 0);
+}
+
+Version? _tryParseVersion(String value) {
+  try {
+    return Version.parse(value.replaceFirst(RegExp(r'^[vV]'), ''));
+  } on FormatException {
+    return null;
+  }
+}
+
+class _UpdateTarget {
+  const _UpdateTarget(this.platform, this.architecture);
+
+  final String platform;
+  final String architecture;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1208,7 +1208,7 @@ packages:
     source: hosted
     version: "1.3.4+1"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,6 +98,7 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.6
   process_run: ^1.3.4+1
+  pub_semver: ^2.2.0
   pointycastle: ^4.0.0
   toml: ^0.18.0
   dart_openai: ^6.1.1

--- a/test/update_service_test.dart
+++ b/test/update_service_test.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:maid_kit/shared/services/maidkit_update_service.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:solsynth_express/solsynth_express.dart';
 
 /// Dio adapter that answers every request with a canned HTTP response.
@@ -43,6 +45,30 @@ SolsynthExpressApi _apiWith(int statusCode, String body) {
 }
 
 void main() {
+  group('MaidKit update version checks', () {
+    test('includes the platform build number in update requests', () {
+      final info = PackageInfo(
+        appName: 'MaidKit',
+        packageName: 'dev.solsynth.maidkit',
+        version: '1.3.0',
+        buildNumber: '20',
+      );
+
+      expect(installedUpdateVersion(info), '1.3.0+20');
+    });
+
+    test('does not offer the installed or an older build', () {
+      expect(isDistributionReleaseNewer('1.3.0+20', '1.3.0+20'), isFalse);
+      expect(isDistributionReleaseNewer('1.3.0+19', '1.3.0+20'), isFalse);
+      expect(isDistributionReleaseNewer('1.3.0', '1.3.0+20'), isFalse);
+    });
+
+    test('offers a newer build or app version', () {
+      expect(isDistributionReleaseNewer('1.3.0+21', '1.3.0+20'), isTrue);
+      expect(isDistributionReleaseNewer('1.4.0+1', '1.3.0+20'), isTrue);
+    });
+  });
+
   group('SolsynthExpressApi releases', () {
     test('parses a release and compatible artifacts', () async {
       final release = await _apiWith(


### PR DESCRIPTION
## Summary

- report the complete installed version, including the platform build number, to Solsynth Express
- reject server-side update results when the published version/build is not newer
- hide the latest-release action when that release is already installed
- cover equal, older, newer-build, and newer-version comparisons

## Why

Android reports MaidKit `1.3.0+20` as version `1.3.0` plus build `20`. The shared updater sent only `1.3.0`, so the same `1.3.0+20` artifact could be offered after it was already installed.

## Validation

- targeted Dart analysis — no issues
- update comparison regression cases added
- Flutter tests are currently blocked on Windows by the existing `tailscale 0.8.0` native build referencing POSIX-only symbols

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Solsynth/codesmith/MaidKit/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789278714&installation_model_id=431261&pr_number=37&repository=Solsynth%2FMaidKit&return_to=https%3A%2F%2Fgithub.com%2FSolsynth%2FMaidKit%2Fpull%2F37&signature=3b22a31a5243bca10eedacc6182c83028126811114bd6ef74f033bdedf3882e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->