### PR TITLE
修复 material_ui 树下原生 Material 组件导致的崩溃

### DIFF
--- a/lib/shared/presentation/maidkit_window_scaffold.dart
+++ b/lib/shared/presentation/maidkit_window_scaffold.dart
@@ -36,19 +36,31 @@ class MaidKitWindowScaffold extends ConsumerWidget {
       // uses the modular material_ui package.
       child: flutter.Theme(
         data: _createWindowFrameTheme(Theme.of(context)),
-        child: DesktopWindowFrame(
-          isDesktopPlatform: isDesktop,
-          title: Text(
-            title ?? 'MaidKit',
-            style: Theme.of(context).textTheme.labelLarge,
-          ),
-          // Routes own their safe areas. Consuming mobile insets here prevents
-          // page scaffolds from participating correctly in gesture-back.
-          child: Column(
-            children: [
-              Expanded(child: child),
-              const TaskProgressBar(),
-            ],
+        // material_ui 和 Flutter 原生 Material 各有一套 RenderInkFeatures,
+        // 原生 Ink/InkWell 在 material_ui 的树里找不到祖先,release 下就是
+        // "Null check operator used on a null value"(Material.of 里的 result!)。
+        // 以下依赖仍用原生 material,且在 pub cache 里改不了,故在此统一兜底:
+        //   flutter_code_editor      搜索框 / 补全弹窗的 InkWell
+        //   markdown_widget          链接、图片的 InkWell,目录的 ListTile
+        //   solar_network_foundation InputChip
+        //   update_settings_section  SwitchListTile / DropdownButtonFormField / ListTile
+        // 透明 Material 只补这个祖先,不绘制任何背景。
+        child: flutter.Material(
+          type: flutter.MaterialType.transparency,
+          child: DesktopWindowFrame(
+            isDesktopPlatform: isDesktop,
+            title: Text(
+              title ?? 'MaidKit',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            // Routes own their safe areas. Consuming mobile insets here prevents
+            // page scaffolds from participating correctly in gesture-back.
+            child: Column(
+              children: [
+                Expanded(child: child),
+                const TaskProgressBar(),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
在 Linux release 构建下，应用启动即抛出 Null check operator used on a null value，随后 widget 树连锁崩塌，输出大量 Another exception was thrown。
首个异常的调用栈：
Null check operator used on a null value
#0  Material.of (package:flutter/src/material/material.dart:423)
#1  _InkState._build (package:flutter/src/material/ink_decoration.dart:285)

原因分析：
自 947bfea 迁移到 material_ui 后，整棵 widget 树的根是 material_ui 的 Material。该包自带一套 RenderInkFeatures，与 Flutter 原生的是不同的类型。于是树中任何原生 Ink / InkWell 在
findAncestorRenderObjectOfType<RenderInkFeatures>() 时都会落空，Material.of() 里的 result! 抛出异常。debug 下有 assert 给出友好提示，release 下则直接崩溃。

以下依赖仍在使用原生 material，且都位于 pub cache 中无法修改：
- flutter_code_editor — 搜索框、自动补全弹窗的 InkWell
- markdown_widget — 链接与图片的 InkWell、目录的 ListTile
- solar_network_foundation — InputChip
- 本仓库的 update_settings_section.dart — SwitchListTile / DropdownButtonFormField / ListTile

解决方案:
在窗口脚手架统一加一层透明 Material 兜底。MaterialType.transparency 不绘制任何背景，视觉上没有变化。改动处附了注释列明它兜住的范围，以免日后被误删。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Solsynth/codesmith/MaidKit/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789280094&installation_model_id=431261&pr_number=40&repository=Solsynth%2FMaidKit&return_to=https%3A%2F%2Fgithub.com%2FSolsynth%2FMaidKit%2Fpull%2F40&signature=2261f68b311feb55118357df0b9e4232485e2dfe647584000c06a84abd7eb30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->