### PR TITLE
fix: accept whitespace-only SSH passwords

### DIFF
--- a/lib/servers/credentials_page.dart
+++ b/lib/servers/credentials_page.dart
@@ -206,6 +206,8 @@ class _CredentialEditorSheetState extends State<_CredentialEditorSheet> {
 
   String? _required(String? value) =>
       value == null || value.trim().isEmpty ? 'commonRequired'.tr() : null;
+  String? _requiredSecret(String? value) =>
+      value == null || value.isEmpty ? 'commonRequired'.tr() : null;
 
   Future<void> _pickKey() async {
     final result = await FilePicker.pickFiles(withData: true);
@@ -274,7 +276,7 @@ class _CredentialEditorSheetState extends State<_CredentialEditorSheet> {
                 decoration: InputDecoration(
                   labelText: 'serverPasswordLabel'.tr(),
                 ),
-                validator: _required,
+                validator: _requiredSecret,
               )
             else ...[
               TextFormField(

--- a/lib/servers/servers_page.dart
+++ b/lib/servers/servers_page.dart
@@ -2045,6 +2045,8 @@ class _AddServerDialogState extends ConsumerState<ServerEditorDialog> {
 
   String? _required(String? value) =>
       value == null || value.trim().isEmpty ? 'serverPortRequired'.tr() : null;
+  String? _requiredSecret(String? value) =>
+      value == null || value.isEmpty ? 'serverPortRequired'.tr() : null;
   String? _validPort(String? value) {
     final port = int.tryParse(value ?? '');
     return port != null && port > 0 && port < 65536
@@ -2313,7 +2315,7 @@ class _AddServerDialogState extends ConsumerState<ServerEditorDialog> {
                       decoration: InputDecoration(
                         labelText: 'serverPasswordLabel'.tr(),
                       ),
-                      validator: _required,
+                      validator: _requiredSecret,
                     )
                   else ...[
                     TextFormField(

--- a/test/servers_page_test.dart
+++ b/test/servers_page_test.dart
@@ -41,6 +41,17 @@ void main() {
     expect(find.text('serverConnectionSerial'.tr()), findsNothing);
   });
 
+  testWidgets('accepts whitespace-only SSH passwords', (tester) async {
+    await pumpEditor(tester);
+
+    final password = find.byType(TextFormField).last;
+    await tester.enterText(password, '     ');
+    await tester.tap(find.text('commonSave'.tr()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ServerEditorDialog), findsNothing);
+  });
+
   testWidgets('advanced server sections start collapsed', (tester) async {
     await pumpEditor(tester);
 


### PR DESCRIPTION
修复 SSH 密码为纯空格时保存触发必填校验的问题。

密码字段现在仅在真正为空字符串时提示必填，并新增回归测试覆盖五个空格密码。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Solsynth/codesmith/MaidKit/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790953504&installation_model_id=431261&pr_number=78&repository=Solsynth%2FMaidKit&return_to=https%3A%2F%2Fgithub.com%2FSolsynth%2FMaidKit%2Fpull%2F78&signature=ef2e1ae81ce68fc66b61383f877213f1419271165db5090e62543f3c06d4d7b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->